### PR TITLE
ci: bump sonarqube action

### DIFF
--- a/sonarqube/action.yml
+++ b/sonarqube/action.yml
@@ -28,7 +28,7 @@ runs:
         java-version: '11.x'
 
     - name: Setup sonar-scanner
-      uses: warchant/setup-sonar-scanner@v7
+      uses: warchant/setup-sonar-scanner@v8
 
     - name: Test coverage cache
       uses: actions/cache@v4


### PR DESCRIPTION
<img width="1552" alt="image" src="https://github.com/skore-io/skore-front/assets/19170390/4fd8de17-77b2-4a79-b3e6-877e955332bf">

### What?

Atualizando versão do `sonarqube` no CI/CD para remover warnings do github actions.

### Why?

A `v8` usa a versão mais recente do nodejs: https://github.com/Warchant/setup-sonar-scanner/releases/tag/v8

