### PR TITLE
ci(workflow): fix sonarqube pr-block

### DIFF
--- a/sonarqube/action.yml
+++ b/sonarqube/action.yml
@@ -12,14 +12,8 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Get branch of PR
-      uses: skore-io/git-actions/pr-block/pull-request-comment-branch@main
-      id: comment-branch
-
     - name: Checkout repository
       uses: actions/checkout@v4
-      with:
-        ref: ${{ steps.comment-branch.outputs.head_sha }}
 
     - name: Setup Java 11
       uses: actions/setup-java@v4
@@ -39,16 +33,6 @@ runs:
           ./test-reporter.xml
           ./coverage
         key: ${{ runner.os }}-build-${{ github.sha }}
-
-    - name: Test coverage cache
-      uses: actions/cache@v4
-      env:
-        cache-name: cache-test-reporter
-      with:
-        path: |
-          ./test-reporter.xml
-          ./coverage
-        key: ${{ runner.os }}-build-${{ steps.comment-branch.outputs.head_sha }}
 
     - name: SonarQube
       shell: bash


### PR DESCRIPTION
![your incredible giphy](https://c.tenor.com/E1GwVS-1nNYAAAAC/tenor.gif)

### What?

Removendo `pr-block` do composite do sonarqube.

### Why?

Deletamos o composite que era usado para fazer o `@run-tests` e quebramos a pipe do sonarqube: https://github.com/skore-io/git-actions/pull/5
