### PR TITLE
feat: open pr notifier

### DIFF
--- a/open-pr-notifier/README.md
+++ b/open-pr-notifier/README.md
@@ -1,0 +1,35 @@
+# Open PR Notifier
+
+Esta action verifica PRs abertos e envia notificações automáticas baseadas no tempo que estão abertos. Ela também pode fechar automaticamente PRs que ficam muito tempo sem atividade.
+
+## Funcionalidades
+
+- Notifica quando um PR está aberto há 1 dia sem revisões
+- Notifica quando um PR está aberto há 3 dias
+- Notifica quando um PR está aberto há 4 dias
+- Notifica quando um PR está aberto há 5 dias
+- Fecha automaticamente PRs que estão abertos há 7 dias e sem atividade por 1 dia
+
+## Como usar
+
+```yaml
+name: Open PR Notifier
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 12 * * *' # Every day at 9am BRT
+
+jobs:
+  notify-open-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: skore-io/git-actions/open-pr-notifier@main
+```
+
+## Permissões necessárias
+
+Esta action requer as seguintes permissões:
+
+- `pull-requests: write`
+- `issues: write`

--- a/open-pr-notifier/action.yml
+++ b/open-pr-notifier/action.yml
@@ -1,0 +1,95 @@
+name: Open PR Notifier
+description: Notify about open PRs for a long time and perform automatic actions
+
+runs:
+  using: composite
+
+  steps:
+    - name: Check PRs and notify
+      uses: actions/github-script@v7
+      shell: bash
+      with:
+        github-token: ${{ github.token }}
+        script: |
+          const now = new Date();
+
+          const { data: prs } = await github.rest.pulls.list({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            state: 'open',
+            per_page: 100,
+          });
+
+          for (const pr of prs) {
+            const createdAt = new Date(pr.created_at);
+            const updatedAt = new Date(pr.updated_at);
+
+            const daysOpen = Math.floor((now - createdAt) / (1000 * 60 * 60 * 24));
+            const daysSinceUpdate = Math.floor((now - updatedAt) / (1000 * 60 * 60 * 24));
+
+            console.info(`PR #${pr.number}: ${daysOpen} days open, ${daysSinceUpdate} days since update`);
+
+            if (daysOpen >= 1 && daysOpen < 3) {
+              const { data: reviews } = await github.rest.pulls.listReviews({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number
+              });
+
+              const validReviews = reviews.filter(r =>
+                ['APPROVED', 'CHANGES_REQUESTED', 'COMMENTED'].includes(r.state)
+              );
+
+              if (validReviews.length === 0) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  body: `⚠️ Esse PR tá aberto há 1 dia e ainda não recebeu nenhuma revisão. Que tal acionar seu time?`
+                });
+              }
+            }
+
+            if (daysOpen === 3) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: `📣 Esse PR tá aberto há 3 dias. Tem algo travando ou já dá pra seguir com QA?`
+              });
+            }
+
+            if (daysOpen === 4) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: `🟡 Esse PR tá aberto há 4 dias. Conquista desbloqueada: "PR lendário em modo espera" 🏅`
+              });
+            }
+
+            if (daysOpen === 5) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: `🚨 Esse PR tá por aqui há 5 dias. Tá tudo certo? Se tiver algo travando, o time pode dar uma força.`
+              });
+            }
+
+            if (daysOpen >= 7 && daysSinceUpdate >= 1) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: `❌ Esse PR chegou a 7 dias aberto e ficou 1 dia sem atividade. Estamos fechando automaticamente.`
+              });
+
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                state: 'closed'
+              });
+            }
+          }


### PR DESCRIPTION
### What?

Adicionando composite do github para notificar PRs que estão abertos sem terem atividades (reviews, comentários, etc), ou abertos há muito tempo.

Regras:

| Ação                          | Quando rodar?                          | Mensagem                                                                 |
|------------------------------|----------------------------------------|--------------------------------------------------------------------------|
| ⚠️ Alerta: sem review         | **Após 1 dia aberto, sem nenhuma review** | Esse PR tá aberto há 1 dia e ainda não recebeu nenhuma revisão.         |
| 📣 Lembrete de acompanhamento | **Após 3 dias abertos**                | Esse PR tá aberto há 3 dias. Tem algo travando ou já dá pra seguir com QA? |
| 🟡 Piadinha/Alerta leve       | **Após 4 dias abertos**                | Conquista desbloqueada: PR lendário em modo espera 🏅                   |
| 🚨 Último aviso               | **Após 5 dias abertos**                | Esse PR tá por aqui há 5 dias. Tá tudo certo? O time pode ajudar.      |
| ❌ Fechamento automático      | **Após 7 dias abertos + 1 dia sem atividade** | Esse PR chegou a 7 dias aberto e ficou 1 dia sem atividade. Estamos fechando automaticamente. |

### Why?

Definir um ciclo de vida do PR, para que ele não fique aberto ou sem reviews por muito tempo.
Vamos testar esses valores da tabela, e podemos ajustar conforme necessidade.