### PR TITLE
feat: auto assign pr to creator

### DIFF
--- a/assign-pr/README.md
+++ b/assign-pr/README.md
@@ -1,0 +1,28 @@
+# Assign PR
+
+Esta action atribui automaticamente o PR ao seu criador quando um novo PR é aberto.
+
+## Como usar
+
+```yaml
+name: Assign PR to creator
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  assign_pr:
+    name: Assign
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: skore-io/git-actions/assign-pr@main
+```
+
+## Permissões necessárias
+
+Esta action requer as seguintes permissões:
+
+- `contents: read`
+- `pull-requests: write`

--- a/assign-pr/action.yml
+++ b/assign-pr/action.yml
@@ -1,0 +1,12 @@
+name: Assign PR
+description: Automatically assign PR to its creator
+
+runs:
+  using: composite
+
+  steps:
+    - name: Assign PR to creator
+      uses: toshimaru/auto-author-assign@v2.1.1
+      shell: bash
+      with:
+        repo-token: ${{ github.token }}

--- a/open-pr-notifier/README.md
+++ b/open-pr-notifier/README.md
@@ -21,8 +21,9 @@ on:
     - cron: '0 12 * * *' # Every day at 9am BRT
 
 jobs:
-  notify-open-prs:
+  notify_open_prs:
     runs-on: ubuntu-latest
+
     steps:
       - uses: skore-io/git-actions/open-pr-notifier@main
 ```


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b57f6c45-8c98-4f9f-819c-127d26dcc871)

### What?

Adicionando action para colocar o criador do PR como assignee.
Estamos usando essa lib: https://github.com/toshimaru/auto-author-assign

### Why?

Fica mais fácil identificar quem abriu o PR 😃 