### PR TITLE
ci(workflow): fix sonarqube params

### DIFF
--- a/sonarqube/action.yml
+++ b/sonarqube/action.yml
@@ -47,7 +47,7 @@ runs:
         -Dsonar.coverage.exclusions='src/main.ts,**/*.test.ts,**/*index.ts,**/*.module.ts,src/**/database/migration/*.ts,src/**/database/seed/*.ts,src/**/dto/*.ts,**/interceptor/*.ts,src/newrelic.ts,src/**/entity/*.ts'
         -Dsonar.cpd.exclusions='**/*.test.ts,src/**/dto/*.ts,src/**/database/migration/*.ts,src/**/entity/*.ts'
         -Dsonar.testExecutionReportPaths=test-reporter.xml
-        -Dsonar.pullrequest.key=${{ steps.comment-branch.outputs.number }}
-        -Dsonar.pullrequest.branch=${{ steps.comment-branch.outputs.head_ref }}
-        -Dsonar.pullrequest.base=develop
-        -Dsonar.scm.revision=${{ steps.comment-branch.outputs.head_sha }}
+        -Dsonar.pullrequest.key=${{ github.event.number }}
+        -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }}
+        -Dsonar.pullrequest.base=homolog
+        -Dsonar.scm.revision=${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
![your incredible giphy](https://c.tenor.com/UVpwNykJUkAAAAAd/tenor.gif)

### What?

Ajustando parâmetros do sonarqube que anteriormente eram obtidos do composite de `pr-block`.

### Why?

Deletamos o composite que era usado para fazer o `@run-tests` (pr https://github.com/skore-io/git-actions/pull/5) e quebramos a pipe do sonarqube.
