### PR TITLE
fix(open_pr_notifier): message to prs without activity

### DIFF
--- a/k8s/action.yml
+++ b/k8s/action.yml
@@ -165,7 +165,7 @@ runs:
         sed -i '/##TOLERATION##/r tolerations.yaml' .k8s/worker-deployment.tpl.yaml
         sed -i "s|##AFFINITY##||g" .k8s/worker-deployment.tpl.yaml
         sed -i "s|##TOLERATION##||g" .k8s/worker-deployment.tpl.yaml
-        
+
         rm affinity.yaml
         rm tolerations.yaml
         fi

--- a/open-pr-notifier/README.md
+++ b/open-pr-notifier/README.md
@@ -4,7 +4,7 @@ Esta action verifica PRs abertos e envia notificações automáticas baseadas no
 
 ## Funcionalidades
 
-- Notifica quando um PR está aberto há 1 dia sem revisões
+- Notifica quando um PR está aberto há 1 ou 2 dias sem revisões
 - Notifica quando um PR está aberto há 3 dias
 - Notifica quando um PR está aberto há 4 dias
 - Notifica quando um PR está aberto há 5 dias
@@ -13,14 +13,14 @@ Esta action verifica PRs abertos e envia notificações automáticas baseadas no
 
 ## Regras
 
-| Ação                          | Quando rodar?                                | Mensagem                                                                                                                                                                         |
-| ----------------------------- | -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ⚠️ Alerta: sem review         | **Após 1 dia aberto, sem nenhuma review**    | Esse PR tá aberto há 1 dia e ainda não recebeu nenhuma revisão. Que tal dar um ping na galera pra revisar?                                                                       |
-| 📣 Lembrete de acompanhamento | **Após 3 dias aberto**                       | Esse PR tá aberto há 3 dias. Tem algo travando ou já dá pra seguir com QA?                                                                                                       |
-| ⏳ Alerta de inatividade      | **Após 4 dias aberto**                       | Esse PR tá aberto há 4 dias. Que tal dar um gás nele?                                                                                                                            |
-| 🚨 Check-in de status         | **Após 5 dias aberto**                       | Esse PR tá por aqui há 5 dias. Tá tudo certo? Se tiver algo travando, o time pode dar uma força — tamo junto!                                                                    |
-| ⏰ Alerta final               | **Após 7 dias aberto**                       | 7 dias de PR! Você desbloqueou a conquista: "PR lendário em modo espera" 🏅<br><br>Se não houver atividade nas próximas 24h, ele será fechado automaticamente. Bora evitar isso? |
-| ❌ Fechamento automático      | **Após 7 dias aberto + 1 dia sem atividade** | Esse PR ficou aberto por X dias e sem atualizações nas últimas 24h. Fechando automaticamente — se ainda for relevante, sinta-se à vontade pra reabrir.                           |
+| Ação                          | Quando rodar?                                  | Mensagem                                                                                                                                                                         |
+| ----------------------------- | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ⚠️ Alerta: sem review         | **Após 1 ou 2 dias aberto, sem nenhum review** | Esse PR tá aberto há x dias e ainda não recebeu nenhuma revisão. Que tal dar um ping na galera pra revisar?                                                                      |
+| 📣 Lembrete de acompanhamento | **Após 3 dias aberto**                         | Esse PR tá aberto há 3 dias. Tem algo travando ou já dá pra seguir com QA?                                                                                                       |
+| ⏳ Alerta de inatividade      | **Após 4 dias aberto**                         | Esse PR tá aberto há 4 dias. Que tal dar um gás nele?                                                                                                                            |
+| 🚨 Check-in de status         | **Após 5 dias aberto**                         | Esse PR tá por aqui há 5 dias. Tá tudo certo? Se tiver algo travando, o time pode dar uma força — tamo junto!                                                                    |
+| ⏰ Alerta final               | **Após 7 dias aberto**                         | 7 dias de PR! Você desbloqueou a conquista: "PR lendário em modo espera" 🏅<br><br>Se não houver atividade nas próximas 24h, ele será fechado automaticamente. Bora evitar isso? |
+| ❌ Fechamento automático      | **Após 7 dias aberto + 1 dia sem atividade**   | Esse PR ficou aberto por X dias e sem atualizações nas últimas 24h. Fechando automaticamente — se ainda for relevante, sinta-se à vontade pra reabrir.                           |
 
 ## Como usar
 

--- a/open-pr-notifier/action.yml
+++ b/open-pr-notifier/action.yml
@@ -44,7 +44,7 @@ runs:
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: pr.number,
-                  body: `⚠️ Esse PR tá aberto há 1 dia e ainda não recebeu nenhuma revisão. Que tal dar um ping na galera pra revisar?`
+                  body: `⚠️ Esse PR tá aberto há ${daysOpen === 1 ? '1 dia' : `${daysOpen} dias`} e ainda não recebeu nenhuma revisão. Que tal dar um ping na galera pra revisar?`
                 });
               }
             }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0a147633-a202-40cb-8c4e-c05da8727421)

### What?

Ajustando mensagem de PR sem atividades nos 2 primeiros dias.

### Why?

A mensagem era enviada no segundo dia com o texto `Esse PR tá aberto há 1 dia...` (print do PR)
