### PR TITLE
feat(open_pr_notifier): use business days

### DIFF
--- a/open-pr-notifier/README.md
+++ b/open-pr-notifier/README.md
@@ -2,25 +2,16 @@
 
 Esta action verifica PRs abertos e envia notificações automáticas baseadas no tempo que estão abertos. Ela também pode fechar automaticamente PRs que ficam muito tempo sem atividade.
 
-## Funcionalidades
-
-- Notifica quando um PR está aberto há 1 ou 2 dias sem revisões
-- Notifica quando um PR está aberto há 3 dias
-- Notifica quando um PR está aberto há 4 dias
-- Notifica quando um PR está aberto há 5 dias
-- Notifica quando um PR está aberto há 7 dias
-- Fecha automaticamente PRs que estão abertos há mais de 7 dias e sem atividade por 1 dia
-
 ## Regras
-
+Veja abaixo uma tabela com as regras:
 | Ação                          | Quando rodar?                                  | Mensagem                                                                                                                                                                         |
 | ----------------------------- | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ⚠️ Alerta: sem review         | **Após 1 ou 2 dias aberto, sem nenhum review** | Esse PR tá aberto há x dias e ainda não recebeu nenhuma revisão. Que tal dar um ping na galera pra revisar?                                                                      |
-| 📣 Lembrete de acompanhamento | **Após 3 dias aberto**                         | Esse PR tá aberto há 3 dias. Tem algo travando ou já dá pra seguir com QA?                                                                                                       |
-| ⏳ Alerta de inatividade      | **Após 4 dias aberto**                         | Esse PR tá aberto há 4 dias. Que tal dar um gás nele?                                                                                                                            |
-| 🚨 Check-in de status         | **Após 5 dias aberto**                         | Esse PR tá por aqui há 5 dias. Tá tudo certo? Se tiver algo travando, o time pode dar uma força — tamo junto!                                                                    |
-| ⏰ Alerta final               | **Após 7 dias aberto**                         | 7 dias de PR! Você desbloqueou a conquista: "PR lendário em modo espera" 🏅<br><br>Se não houver atividade nas próximas 24h, ele será fechado automaticamente. Bora evitar isso? |
-| ❌ Fechamento automático      | **Após 7 dias aberto + 1 dia sem atividade**   | Esse PR ficou aberto por X dias e sem atualizações nas últimas 24h. Fechando automaticamente — se ainda for relevante, sinta-se à vontade pra reabrir.                           |
+| ⚠️ Alerta: sem review         | **Após 1 dia útil aberto, sem nenhum review**             | Esse PR tá aberto há 1 dia útil e ainda não recebeu nenhuma revisão. Que tal dar um ping na galera pra revisar? |
+| 📣 Lembrete de acompanhamento | **Após 2 dias úteis aberto**                              | Esse PR tá aberto há 2 dias úteis. Tem algo travando ou já dá pra seguir com QA? |
+| ⏳ Alerta de inatividade      | **Após 3 dias úteis aberto**                              | Esse PR tá aberto há 3 dias úteis. Que tal dar um gás nele? |
+| 🚨 Check-in de status         | **Após 4 dias úteis aberto**                              | Esse PR tá por aqui há 4 dias úteis. Tá tudo certo? Se tiver algo travando, o time pode dar uma força — tamo junto! |
+| ⏰ Alerta final               | **Após 5 dias úteis aberto**                              | 5 dias úteis de PR! Você desbloqueou a conquista: "PR lendário em modo espera". Se não houver atividade nas próximas 24h, ele será fechado automaticamente. Bora evitar isso? |
+| ❌ Fechamento automático      | **Após 5 dias úteis aberto + 1 dia útil sem atividade**   | Esse PR ficou aberto por X dias e sem atualizações nas últimas 24h. Fechando automaticamente — se ainda for relevante, sinta-se à vontade pra reabrir. |
 
 ## Como usar
 

--- a/open-pr-notifier/action.yml
+++ b/open-pr-notifier/action.yml
@@ -11,6 +11,10 @@ runs:
         github-token: ${{ github.token }}
         script: |
           function getBusinessDays(startDate, endDate) {
+            if (startDate.getHours() >= 16) {
+              startDate.setDate(startDate.getDate() + 1);
+            }
+
             let count = 0;
             const curDate = new Date(startDate.getTime());
 

--- a/open-pr-notifier/action.yml
+++ b/open-pr-notifier/action.yml
@@ -47,7 +47,7 @@ runs:
 
             console.info(`PR #${pr.number}: ${daysOpen} business days open, ${daysSinceUpdate} business days since update`);
 
-            if (daysOpen >= 1 && daysOpen < 3) {
+            if (daysOpen === 1) {
               const { data: reviews } = await github.rest.pulls.listReviews({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -63,9 +63,18 @@ runs:
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: pr.number,
-                  body: `⚠️ Esse PR tá aberto há ${daysOpen === 1 ? '1 dia útil' : `${daysOpen} dias úteis`} e ainda não recebeu nenhuma revisão. Que tal dar um ping na galera pra revisar?`
+                  body: `⚠️ Esse PR tá aberto há 1 dia útil e ainda não recebeu nenhuma revisão. Que tal dar um ping na galera pra revisar?`
                 });
               }
+            }
+
+            if (daysOpen === 2) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: `📣 Esse PR tá aberto há 2 dias úteis. Tem algo travando ou já dá pra seguir com QA?`
+              });
             }
 
             if (daysOpen === 3) {
@@ -73,7 +82,7 @@ runs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: pr.number,
-                body: `📣 Esse PR tá aberto há 3 dias úteis. Tem algo travando ou já dá pra seguir com QA?`
+                body: `⏳ Esse PR tá aberto há 3 dias úteis. Que tal dar um gás nele?`
               });
             }
 
@@ -82,7 +91,7 @@ runs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: pr.number,
-                body: `⏳ Esse PR tá aberto há 4 dias úteis. Que tal dar um gás nele?`
+                body: `🚨 Esse PR tá por aqui há 4 dias úteis. Tá tudo certo? Se tiver algo travando, o time pode dar uma força — tamo junto!`
               });
             }
 
@@ -91,22 +100,13 @@ runs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: pr.number,
-                body: `🚨 Esse PR tá por aqui há 5 dias úteis. Tá tudo certo? Se tiver algo travando, o time pode dar uma força — tamo junto!`
-              });
-            }
-
-            if (daysOpen === 7) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr.number,
-                body: `⏰ 7 dias úteis de PR! Você desbloqueou a conquista: "PR lendário em modo espera" 🏅
+                body: `⏰ 5 dias úteis de PR! Você desbloqueou a conquista: "PR lendário em modo espera" 🏅
 
                 Se não houver atividade nas próximas 24h, ele será fechado automaticamente. Bora evitar isso?`
               });
             }
 
-            if (daysOpen > 7 && daysSinceUpdate >= 1) {
+            if (daysOpen > 5 && daysSinceUpdate >= 1) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/open-pr-notifier/action.yml
+++ b/open-pr-notifier/action.yml
@@ -10,6 +10,21 @@ runs:
       with:
         github-token: ${{ github.token }}
         script: |
+          function getBusinessDays(startDate, endDate) {
+            let count = 0;
+            const curDate = new Date(startDate.getTime());
+
+            while (curDate <= endDate) {
+              const dayOfWeek = curDate.getDay();
+
+              if (dayOfWeek !== 0 && dayOfWeek !== 6) count++;
+
+              curDate.setDate(curDate.getDate() + 1);
+            }
+
+            return count;
+          }
+
           const now = new Date();
 
           const { data: prs } = await github.rest.pulls.list({
@@ -23,10 +38,10 @@ runs:
             const createdAt = new Date(pr.created_at);
             const updatedAt = new Date(pr.updated_at);
 
-            const daysOpen = Math.floor((now - createdAt) / (1000 * 60 * 60 * 24));
-            const daysSinceUpdate = Math.floor((now - updatedAt) / (1000 * 60 * 60 * 24));
+            const daysOpen = getBusinessDays(createdAt, now);
+            const daysSinceUpdate = getBusinessDays(updatedAt, now);
 
-            console.info(`PR #${pr.number}: ${daysOpen} days open, ${daysSinceUpdate} days since update`);
+            console.info(`PR #${pr.number}: ${daysOpen} business days open, ${daysSinceUpdate} business days since update`);
 
             if (daysOpen >= 1 && daysOpen < 3) {
               const { data: reviews } = await github.rest.pulls.listReviews({
@@ -44,7 +59,7 @@ runs:
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: pr.number,
-                  body: `⚠️ Esse PR tá aberto há ${daysOpen === 1 ? '1 dia' : `${daysOpen} dias`} e ainda não recebeu nenhuma revisão. Que tal dar um ping na galera pra revisar?`
+                  body: `⚠️ Esse PR tá aberto há ${daysOpen === 1 ? '1 dia útil' : `${daysOpen} dias úteis`} e ainda não recebeu nenhuma revisão. Que tal dar um ping na galera pra revisar?`
                 });
               }
             }
@@ -54,7 +69,7 @@ runs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: pr.number,
-                body: `📣 Esse PR tá aberto há 3 dias. Tem algo travando ou já dá pra seguir com QA?`
+                body: `📣 Esse PR tá aberto há 3 dias úteis. Tem algo travando ou já dá pra seguir com QA?`
               });
             }
 
@@ -63,7 +78,7 @@ runs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: pr.number,
-                body: `⏳ Esse PR tá aberto há 4 dias. Que tal dar um gás nele?`
+                body: `⏳ Esse PR tá aberto há 4 dias úteis. Que tal dar um gás nele?`
               });
             }
 
@@ -72,7 +87,7 @@ runs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: pr.number,
-                body: `🚨 Esse PR tá por aqui há 5 dias. Tá tudo certo? Se tiver algo travando, o time pode dar uma força — tamo junto!`
+                body: `🚨 Esse PR tá por aqui há 5 dias úteis. Tá tudo certo? Se tiver algo travando, o time pode dar uma força — tamo junto!`
               });
             }
 
@@ -81,7 +96,7 @@ runs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: pr.number,
-                body: `⏰ 7 dias de PR! Você desbloqueou a conquista: "PR lendário em modo espera" 🏅
+                body: `⏰ 7 dias úteis de PR! Você desbloqueou a conquista: "PR lendário em modo espera" 🏅
 
                 Se não houver atividade nas próximas 24h, ele será fechado automaticamente. Bora evitar isso?`
               });
@@ -92,7 +107,7 @@ runs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: pr.number,
-                body: `Esse PR ficou aberto por ${daysOpen} dias e sem atualizações nas últimas 24h. Fechando automaticamente — se ainda for relevante, sinta-se à vontade pra reabrir.`
+                body: `Esse PR ficou aberto por ${daysOpen} dias úteis e sem atualizações nas últimas 24h. Fechando automaticamente — se ainda for relevante, sinta-se à vontade pra reabrir.`
               });
 
               await github.rest.pulls.update({


### PR DESCRIPTION
![your incredible giphy](https://media3.giphy.com/media/VkMV9TldsPd28/giphy.gif?cid=5a38a5a2m8uvn8vl8slgzwgeaox8we2jau9w7acdfd6ci8io&ep=v1_gifs_search&rid=giphy.gif&ct=g)

### What?
Ajusta o script para levar em consideração apenas dias de trabalho, ignorando finais de semana.

### Why?
Porque se hoje abrimos um PR na sexta, é quase certeza que na segunda teremos uma notificação de PR aberto por muito tempo.

### Any?
- Fiquei em dúvida apenas se a gente muda o alerta máximo (dos 7 dias) para 5 dias, dado que se tratando de dias úteis, são 5 por semana.
- Adicionei uma lógica que se o PR for criado após as 16hrs, ele só começa a contar no dia seguinte, pois a abordagem que eu segui não faz o cálculo baseado em horas.