### PR TITLE
fix(open_pr_notifier): ignores the time and the current day

### DIFF
--- a/open-pr-notifier/action.yml
+++ b/open-pr-notifier/action.yml
@@ -16,8 +16,11 @@ runs:
             }
 
             let count = 0;
-            const now = new Date().setHours(0, 0, 0, 0);
-            const curDate = startDate.setHours(0, 0, 0, 0);
+            const now = new Date();
+            const curDate = startDate;
+
+            now.setHours(0, 0, 0, 0);
+            curDate.setHours(0, 0, 0, 0);
 
             while (curDate < now) {
               const dayOfWeek = curDate.getDay();


### PR DESCRIPTION
![your incredible giphy](https://media1.giphy.com/media/YAnpMSHcurJVS/giphy.gif?cid=5a38a5a25mezo111br77tqhhfpvu19ys3ngn7wlxtdro4xcw&ep=v1_gifs_search&rid=giphy.gif&ct=g)

### What?
Ajusta o script para ignorar o horário (mantendo a validação das 16hrs) e também o dia em que o script executa.

### Why?
Porque se o PR foi aberto hoje e o script rodava hoje, ele contava como 1 dia.
