### PR TITLE
fix(open_pr_notifier): do not act on weekends

### DIFF
--- a/open-pr-notifier/README.md
+++ b/open-pr-notifier/README.md
@@ -1,6 +1,6 @@
 # Open PR Notifier
 
-Esta action verifica PRs abertos e envia notificações automáticas baseadas no tempo que estão abertos. Ela também pode fechar automaticamente PRs que ficam muito tempo sem atividade.
+Esta action verifica PRs abertos e envia notificações automáticas baseadas no tempo que estão abertos. Ela também pode fechar automaticamente PRs que ficam muito tempo sem atividade. Ela atua apenas nos dias de semana, finais de semana são ignorados.
 
 ## Regras
 Veja abaixo uma tabela com as regras:

--- a/open-pr-notifier/action.yml
+++ b/open-pr-notifier/action.yml
@@ -33,6 +33,9 @@ runs:
             return count;
           }
 
+          const dayOfWeek = new Date().getDay();
+          if (dayOfWeek === 0 || dayOfWeek === 6) return;
+
           const { data: prs } = await github.rest.pulls.list({
             owner: context.repo.owner,
             repo: context.repo.repo,


### PR DESCRIPTION
![your incredible giphy](https://media0.giphy.com/media/DyQrKMpqkAhNHZ1iWe/giphy.gif?cid=5a38a5a24z9aygft2ea0smkyt3bp0qp34iofoxqze4n9l0uh&ep=v1_gifs_trending&rid=giphy.gif&ct=g)

### What?
Ajusta o script para não enviar notificações no final de semana.

### Why?
Porque não trabalhamos nos finais de semana (exceto o Renato).
