### PR TITLE
chore(k8s): add missing input

### DIFF
--- a/k8s/action.yml
+++ b/k8s/action.yml
@@ -14,6 +14,9 @@ inputs:
   service_async_base_url:
     description: URL async for k8s project
     required: false
+  service_console_base_url:
+    description: URL console for k8s project
+    required: false
   github_token:
     description: Token for Github project
     required: true


### PR DESCRIPTION
<img width="3152" height="1168" alt="image" src="https://github.com/user-attachments/assets/1827d091-6721-4cc5-a8cf-f59eb2f14678" />

### What?

Adicionando input `service_console_base_url`.

### Why?

Esse input é usado no projeto `keycloak` mas não estava declarado.
